### PR TITLE
chore: reference vars via context as needed

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,10 +11,11 @@ on:
       - dev
 
 env:
-  CLOUD_FUNCTION_MEMORY: 512MB
+  CLOUD_FUNCTION_MEMORY: 512
   CLOUD_FUCNTION_RUN_TIMEOUT: 240s
   SCHEDULE_NAME: monday-morning
   SCHEDULE_CRON: 0 9 * * 1
+  SCHEDULE_DESCRIPTION: "Trigger the projectname-skid bot once a week on monday morning"
 
 concurrency:
   group: "${{ github.head_ref || github.ref }}"
@@ -84,10 +85,10 @@ jobs:
           source_dir: src/skidname
           service_account_email: cloud-function-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
           event_trigger_type: providers/cloud.pubsub/eventTypes/topic.publish
-          event_trigger_resource: projects/${{ secrets.PROJECT_ID }}/topics/$SCHEDULE_NAME-topic
+          event_trigger_resource: projects/${{ secrets.PROJECT_ID }}/topics/${{ env.SCHEDULE_NAME }}-topic
           deploy_timeout: 600
-          memory_mb: $CLOUD_FUNCTION_MEMORY
-          timeout: $CLOUD_FUCNTION_RUN_TIMEOUT
+          memory_mb: ${{ env.CLOUD_FUNCTION_MEMORY }}
+          timeout: ${{ env.CLOUD_FUCNTION_RUN_TIMEOUT }}
           env_vars: STORAGE_BUCKET=${{secrets.STORAGE_BUCKET}}
           secret_volumes: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/app_secrets
@@ -102,7 +103,7 @@ jobs:
         run: |
           if [ ! "$(gcloud scheduler jobs list --location=us-central1 | grep $SCHEDULE_NAME)" ]; then
             gcloud scheduler jobs create pubsub $SCHEDULE_NAME \
-              --description="Trigger the projectname-skid bot once a week on monday morning" \
+              --description="$SCHEDULE_DESCRIPTION" \
               --schedule="$SCHEDULE_CRON" \
               --time-zone=America/Denver \
               --location=us-central1 \
@@ -111,7 +112,7 @@ jobs:
               --quiet
           else
             gcloud scheduler jobs update pubsub $SCHEDULE_NAME \
-              --description="Trigger the projectname-skid bot once a week on monday morning" \
+              --description="$SCHEDULE_DESCRIPTION" \
               --schedule="$SCHEDULE_CRON" \
               --time-zone=America/Denver \
               --location=us-central1 \
@@ -154,10 +155,10 @@ jobs:
           source_dir: src/projectname
           service_account_email: cloud-function-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
           event_trigger_type: providers/cloud.pubsub/eventTypes/topic.publish
-          event_trigger_resource: projects/${{ secrets.PROJECT_ID }}/topics/$SCHEDULE_NAME-topic
+          event_trigger_resource: projects/${{ secrets.PROJECT_ID }}/topics/${{ env.SCHEDULE_NAME }}-topic
           deploy_timeout: 600
-          memory_mb: $CLOUD_FUNCTION_MEMORY
-          timeout: $CLOUD_FUCNTION_RUN_TIMEOUT
+          memory_mb: ${{ env.CLOUD_FUNCTION_MEMORY }}
+          timeout: ${{ env.CLOUD_FUCNTION_RUN_TIMEOUT }}
           env_vars: STORAGE_BUCKET=${{secrets.STORAGE_BUCKET}}
           secret_volumes: |
             /secrets/app/secrets.json=${{secrets.PROJECT_ID}}/app_secrets
@@ -173,7 +174,7 @@ jobs:
         run: |
           if [ ! "$(gcloud scheduler jobs list --location=us-central1 | grep $SCHEDULE_NAME)" ]; then
             gcloud scheduler jobs create pubsub $SCHEDULE_NAME \
-              --description="Trigger the projectname-skid bot once a week on monday morning" \
+              --description="$SCHEDULE_DESCRIPTION" \
               --schedule="$SCHEDULE_CRON" \
               --time-zone=America/Denver \
               --location=us-central1 \
@@ -182,7 +183,7 @@ jobs:
               --quiet
           else
             gcloud scheduler jobs update pubsub $SCHEDULE_NAME \
-              --description="Trigger the projectname-skid bot once a week on monday morning" \
+              --description="$SCHEDULE_DESCRIPTION" \
               --schedule="$SCHEDULE_CRON" \
               --time-zone=America/Denver \
               --location=us-central1 \


### PR DESCRIPTION
Some updates from implementing the vars in the wmrc skid. Vars outside a `run` block need to be referenced by context.